### PR TITLE
Update Angular configurations

### DIFF
--- a/client/e2e/tsconfig.e2e.json
+++ b/client/e2e/tsconfig.e2e.json
@@ -4,7 +4,7 @@
     "outDir": "../out-tsc/e2e",
     "baseUrl": "./",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2020",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -4,13 +4,13 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', '@angular/cli'],
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
-      require('@angular/cli/plugins/karma')
+      require('@angular-devkit/build-angular/plugins/karma')
     ],
     client:{
       clearContext: false // leave Jasmine Spec Runner output visible in browser
@@ -18,9 +18,6 @@ module.exports = function (config) {
     coverageIstanbulReporter: {
       reports: [ 'html', 'lcovonly' ],
       fixWebpackSourcePaths: true
-    },
-    angularCli: {
-      environment: 'dev'
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/client/package.json
+++ b/client/package.json
@@ -11,16 +11,16 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~10.0.14",
-    "@angular/cdk": "^10.2.7",
-    "@angular/common": "~10.0.14",
-    "@angular/compiler": "~10.0.14",
-    "@angular/core": "~10.0.14",
-    "@angular/forms": "~10.0.14",
-    "@angular/material": "^10.2.7",
-    "@angular/platform-browser": "~10.0.14",
-    "@angular/platform-browser-dynamic": "~10.0.14",
-    "@angular/router": "~10.0.14",
+    "@angular/animations": "~12.0.0",
+    "@angular/cdk": "^12.0.0",
+    "@angular/common": "~12.0.0",
+    "@angular/compiler": "~12.0.0",
+    "@angular/core": "~12.0.0",
+    "@angular/forms": "~12.0.0",
+    "@angular/material": "^12.0.0",
+    "@angular/platform-browser": "~12.0.0",
+    "@angular/platform-browser-dynamic": "~12.0.0",
+    "@angular/router": "~12.0.0",
     "bootstrap": "^4.2.1",
     "core-js": "^2.6.2",
     "js-sha256": "latest",
@@ -29,9 +29,9 @@
     "zone.js": "~0.10.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.1000.8",
-    "@angular/cli": "~10.0.8",
-    "@angular/compiler-cli": "~10.0.14",
+    "@angular-devkit/build-angular": "~12.0.0",
+    "@angular/cli": "~12.0.0",
+    "@angular/compiler-cli": "~12.0.0",
     "@types/node": "^12.11.1",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
@@ -46,6 +46,6 @@
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~3.9.5"
+    "typescript": "~4.2.0"
   }
 }

--- a/client/src/tsconfig.app.json
+++ b/client/src/tsconfig.app.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
-    "module": "es2015",
+    "module": "es2020",
     "types": []
   },
   "exclude": [

--- a/client/src/tsconfig.spec.json
+++ b/client/src/tsconfig.spec.json
@@ -4,7 +4,7 @@
     "outDir": "../out-tsc/spec",
     "baseUrl": "./",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2020",
     "types": [
       "jasmine",
       "node"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,12 +7,12 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es2020",
     "typeRoots": [
       "node_modules/@types"
     ],
     "lib": [
-      "es2016",
+      "es2020",
       "dom"
     ]
   }


### PR DESCRIPTION
## Summary
- bump Angular packages to v12 in `package.json`
- switch TypeScript targets to `es2020`
- update Karma config for new CLI plugin

## Testing
- `npx ng build` *(fails: npm unable to reach registry)*
- `npx ng test` *(fails: npm unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68568dd2cbc48326aed8cd361791e589