### PR TITLE
Update Bokeh to 3.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ conda activate angular-bokeh
 pip install -r requirements.txt
 ```
 
-At time of writing the current bokeh version is 2.3.2. It may change. Be sure the Bokeh-JS version located in index.html fits to the bokeh version in python. 
+At time of writing the current bokeh version is 3.0.0. It may change. Be sure the Bokeh-JS version located in index.html fits to the bokeh version in python.
 
 Latest update to Angular 10.
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -9,11 +9,9 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <!--link
-    href="https://cdn.pydata.org/bokeh/release/bokeh-2.1.1.min.css"
-    rel="stylesheet" type="text/css"-->
-  <script src="https://cdn.pydata.org/bokeh/release/bokeh-2.3.2.min.js"></script>
-  <script src="https://cdn.pydata.org/bokeh/release/bokeh-api-2.3.2.min.js"></script>
+  <!-- BokehJS resources matching the installed Python package -->
+  <script src="https://cdn.bokeh.org/bokeh/release/bokeh-3.0.0.min.js"></script>
+  <script src="https://cdn.bokeh.org/bokeh/release/bokeh-api-3.0.0.min.js"></script>
  </head>
 <body>
   <app-root></app-root>

--- a/python/services/chartProvider.py
+++ b/python/services/chartProvider.py
@@ -3,7 +3,7 @@ import numpy as np
 from bokeh.plotting import figure
 from bokeh.embed import json_item
 
-# NOTE: update to 2.3.2
+# NOTE: updated for Bokeh 3.x
 
 class ChartProvider():
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nucosCR>=0.2.7
 nucosObs>=0.3.2
+bokeh>=3.0


### PR DESCRIPTION
## Summary
- pin `bokeh>=3.0`
- update BokehJS cdn links
- note Bokeh 3.x usage in ChartProvider
- update README note about Bokeh version

## Testing
- `pytest`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568dd7b39c8326b96d5e32beb2e283