### PR TITLE
Make server port and path configurable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,14 @@ $ cd ../python/
 $ python app.py
 ```
 
+The server listens on port `9000` by default and serves the Angular build from
+`../client/dist/dev`. You can override these defaults using environment
+variables or command line options:
+
+```
+$ PORT=8080 ANGULAR_DIST_PATH=/path/to/build python app.py --port 8080 --angular-path /path/to/build
+```
+
 in your browser you should see the app being served to:
 
 ```

--- a/python/app.py
+++ b/python/app.py
@@ -1,6 +1,7 @@
 
 import os
 import getpass
+import argparse
 from aiohttp import web
 
 from services.aiohttpServer import AiohttpServer
@@ -18,14 +19,29 @@ import logging
 _root_ = os.path.realpath(os.path.dirname(__file__))
 
 debug.append(False)
-port = 9000
+
+parser = argparse.ArgumentParser(description="Angular-Bokeh server")
+parser.add_argument(
+    "--port",
+    type=int,
+    default=int(os.getenv("PORT", 9000)),
+    help="Port for the web server (env: PORT)",
+)
+parser.add_argument(
+    "--angular-path",
+    default=os.getenv("ANGULAR_DIST_PATH", os.path.join(_root_, "../client/dist/dev")),
+    help="Path to built Angular files (env: ANGULAR_DIST_PATH)",
+)
+
+args = parser.parse_args()
+port = args.port
 
 if __name__ == '__main__':
     ptv = PythonToView()
     server = AiohttpServer(ptv)
     ptv.setServer(server)
 
-    path = os.path.join(_root_, "../client/dist/dev")
+    path = os.path.abspath(args.angular_path)
     if not os.path.exists(path):
         logger.log(lvl="ERROR", msg="build the angular app first")
         exit()


### PR DESCRIPTION
## Summary
- parametrize python server port and Angular build path
- document new options in README

## Testing
- `python -m py_compile python/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685710e22e148326893cd806d21f96b5