### PR TITLE
Update docs and add websocket tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,14 +35,14 @@ OS X & Linux & Windows:
 Install Anaconda and open a conda enabled shell:
 
 ```
-conda create -n angular-bokeh python=3.8 simplejson bokeh aiohttp
+conda create -n angular-bokeh python=3.8 simplejson "bokeh>=3.0" aiohttp
 conda activate angular-bokeh
 pip install -r requirements.txt
 ```
 
-At time of writing the current bokeh version is 3.0.0. It may change. Be sure the Bokeh-JS version located in index.html fits to the bokeh version in python.
-
-Latest update to Angular 10.
+This repository now targets **Bokeh 3.x** and **Angular 12**. Make sure the
+Bokeh-JS version referenced in `client/src/index.html` matches the installed
+Python package.
 
 ## Usage
 

--- a/client/e2e/websocket.e2e-spec.ts
+++ b/client/e2e/websocket.e2e-spec.ts
@@ -1,0 +1,31 @@
+import { browser, by, element, protractor } from 'protractor';
+import { spawn } from 'child_process';
+import * as path from 'path';
+
+describe('Backend websocket', () => {
+  let server: any;
+
+  beforeAll(() => {
+    const python = 'python';
+    const appPath = path.join(__dirname, '..', '..', 'python', 'app.py');
+    server = spawn(python, [appPath], {
+      cwd: path.join(__dirname, '..', '..', 'python'),
+      stdio: 'inherit'
+    });
+    browser.waitForAngularEnabled(false);
+    return browser.sleep(5000);
+  });
+
+  afterAll(() => {
+    if (server) {
+      server.kill();
+    }
+  });
+
+  it('should render chart via websocket', async () => {
+    await browser.get('http://localhost:9000/');
+    const chart = element(by.css('bokeh-chart .bk-root'));
+    await browser.wait(protractor.ExpectedConditions.presenceOf(chart), 10000);
+    expect(await chart.isPresent()).toBe(true);
+  });
+});

--- a/client/src/app/shared/services/bokeh.service.spec.ts
+++ b/client/src/app/shared/services/bokeh.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { BokehService } from './bokeh.service';
+import { MessageService } from '../../core/services/message.service';
+
+class MockMessageService {
+  public sent: any = null;
+  public stream = new Subject<any>();
+  sendMsg(msg: any) { this.sent = msg; }
+  awaitMessage() { return this.stream; }
+}
+
+declare var Bokeh: any;
+
+describe('BokehService', () => {
+  let service: BokehService;
+  let mock: MockMessageService;
+
+  beforeEach(() => {
+    mock = new MockMessageService();
+    (global as any).Bokeh = { embed: { embed_item: jasmine.createSpy('embed_item') } };
+    TestBed.configureTestingModule({
+      providers: [
+        BokehService,
+        { provide: MessageService, useValue: mock }
+      ]
+    });
+    service = TestBed.inject(BokehService);
+  });
+
+  it('should embed chart when data arrives', () => {
+    const div = document.createElement('div');
+    div.id = 'test-div';
+    document.body.appendChild(div);
+
+    service.getChart('test-div');
+
+    mock.stream.next({ name: 'plot', args: { id: 'test-div', item: { foo: 'bar' } } });
+
+    expect(Bokeh.embed.embed_item).toHaveBeenCalledWith({ foo: 'bar' }, 'test-div');
+
+    document.body.removeChild(div);
+  });
+});


### PR DESCRIPTION
## Summary
- refresh README setup instructions for Angular 12 and Bokeh 3
- test that BokehService embeds a chart item when data arrives
- add an end‑to‑end test to check WebSocket communication to the Python backend

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run e2e --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857118d59bc8326a2a67ac61a06203b