### PR TITLE
Remove nvm dependency in setup script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,16 @@ conda activate angular-bokeh
 pip install -r requirements.txt
 ```
 
+
+Before running the setup script make sure Node.js **16.x** is installed
+system-wide. On Debian/Ubuntu based systems you can use the NodeSource
+packages:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
 After creating the conda environment you can install all Node and Python
 dependencies in one step by running the provided setup script:
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 set -e
 
-# Ensure nvm is loaded
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+# Ensure Node 16 is available without using nvm
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required but not installed. Please install Node.js 16.x and rerun this script." >&2
+  exit 1
+fi
 
-# Use Node 16 for Angular 12
-nvm install 16
-nvm use 16
+NODE_MAJOR=$(node -v | cut -d. -f1 | tr -d 'v')
+if [ "$NODE_MAJOR" -ne 16 ]; then
+  echo "Node.js 16.x is required. Current version: $(node -v)" >&2
+  exit 1
+fi
 
 # Install client dependencies
 cd client


### PR DESCRIPTION
## Summary
- check for system-wide Node 16 in `setup.sh` instead of using nvm
- document installing Node.js 16 via NodeSource in README

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run e2e --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685721af5cd883269d4cba14edfa7b80