### PR TITLE
Update zone imports and configs

### DIFF
--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -24,7 +24,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['ChromeHeadless'],
+    singleRun: true,
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    }
   });
 };

--- a/client/protractor.conf.js
+++ b/client/protractor.conf.js
@@ -9,7 +9,10 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ['--headless', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/client/src/polyfills.ts
+++ b/client/src/polyfills.ts
@@ -53,7 +53,7 @@ import 'core-js/es7/reflect';
 /***************************************************************************************************
  * Zone JS is required by Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 

--- a/client/src/test.ts
+++ b/client/src/test.ts
@@ -1,11 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,


### PR DESCRIPTION
## Summary
- switch polyfills to `import 'zone.js'`
- consolidate Zone imports in test bootstrap
- use headless Chrome in Karma and Protractor configs

## Testing
- `npm test --silent` *(fails: Generating browser application bundles)*
- `npm run e2e --silent` *(fails: Chrome failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_68572c1949d48326a51d6eb3451df033