### PR TITLE
Update README with Node.js 16 note

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,9 +52,9 @@ pip install -r requirements.txt
 ```
 
 
-Before running the setup script make sure Node.js **16.x** is installed
-system-wide. On Debian/Ubuntu based systems you can use the NodeSource
-packages:
+Angular 12 requires Node.js **16.x**. Before running the setup script make sure
+this version is installed system-wide. On Debian/Ubuntu based systems you can
+use the NodeSource packages:
 
 ```bash
 curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
@@ -67,6 +67,10 @@ dependencies in one step by running the provided setup script:
 ```bash
 ./setup.sh
 ```
+
+If you install the Node dependencies manually, run `npm install --legacy-peer-deps`
+to avoid Angular peer dependency conflicts. The provided `./setup.sh` script
+already uses this flag.
 
 This repository now targets **Bokeh 3.x** and **Angular 12**. Make sure the
 Bokeh-JS version referenced in `client/src/index.html` matches the installed


### PR DESCRIPTION
## Summary
- document Angular 12's Node.js 16 requirement
- mention using `npm install --legacy-peer-deps` when installing manually
- note that the setup script already uses the flag

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run e2e --silent` *(fails: ng not found)*
- `pytest python`

------
https://chatgpt.com/codex/tasks/task_e_68572e27675c8326bf3d9b5b2bb8546d