### PR TITLE
Add first pytest for chart provider

### DIFF
--- a/python/tests/test_chart_provider.py
+++ b/python/tests/test_chart_provider.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+# Ensure services package can be imported
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from services.chartProvider import ChartProvider
+
+
+def test_chart_provider_returns_bokeh_item():
+    cp = ChartProvider()
+    item = cp.chartExample()
+    assert isinstance(item, dict)
+    # Basic keys expected in a Bokeh JSON item
+    for key in ["target_id", "root_id", "doc", "version"]:
+        assert key in item


### PR DESCRIPTION
## Summary
- add `test_chart_provider` verifying Bokeh chart JSON structure

## Testing
- `npm test --silent` *(fails: No binary for ChromeHeadless)*
- `npm run e2e --silent`
- `PYTHONPATH=python pytest -q python/tests`

------
https://chatgpt.com/codex/tasks/task_e_68597f8a2324832688d8099a51e8d023