### PR TITLE
Fix Angular project settings

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -138,5 +138,4 @@
       }
     }
   },
-  "defaultProject": "ng-three-template"
 }

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e ng-three-template-e2e"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- remove invalid `defaultProject` from Angular workspace
- update npm `e2e` script to use `ng-three-template-e2e`

## Testing
- `npm test --silent` *(fails: No binary for ChromeHeadless)*
- `npm run e2e --silent` *(prints Protractor deprecation message)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685986a8e7648326ba8758b0fb4d78a3